### PR TITLE
Tuning mixupvi

### DIFF
--- a/benchmark_utils/__init__.py
+++ b/benchmark_utils/__init__.py
@@ -15,7 +15,7 @@ from .dataset_utils import (
     create_dirichlet_pseudobulk_dataset,
 )
 from .latent_signature_utils import create_latent_signature
-from .training_utils import fit_scvi, fit_destvi, fit_mixupvi
+from .training_utils import fit_scvi, fit_destvi, fit_mixupvi, tune_mixupvi
 from .plotting_utils import (
     plot_purified_deconv_results,
     plot_deconv_results,
@@ -26,6 +26,7 @@ from .plotting_utils import (
     plot_reconstruction_loss,
     plot_kl_loss,
     plot_pearson_random,
+    compare_tuning_results,
 )
 from .signature_utils import (
     create_signature,
@@ -37,4 +38,8 @@ from .sanity_checks_utils import (
     run_sanity_check,
     run_categorical_value_checks,
     run_incompatible_value_checks
+)
+from .tuning_utils import(
+    read_tuning_results,
+    read_search_space,
 )

--- a/benchmark_utils/plotting_utils.py
+++ b/benchmark_utils/plotting_utils.py
@@ -184,3 +184,27 @@ def plot_pearson_random(model_history, train: bool = True, n_epochs: int = 100):
     plt.legend()
     plt.title(f"{suffix} metrics")
     plt.show()
+
+
+def compare_tuning_results(
+      all_results, variable_to_plot: str, variable_tuned: str, n_epochs: int = 100, hp_index_to_plot: list = None
+):
+    """Plot the train or val losses for a selection of hyperparameters."""
+    all_hp = all_results.hyperparameter.unique()
+    all_hp.sort()
+    if hp_index_to_plot is None:
+        # plot all HPs
+        hp_index_to_plot = range(len(all_hp))
+
+    plt.clf()
+    for i, hp in enumerate(all_hp):
+        if i in hp_index_to_plot:
+            model_history = all_results.loc[all_results.hyperparameter == hp]
+            plt.plot(
+                range(n_epochs),
+                model_history[variable_to_plot],
+                label=f"{variable_tuned}={hp}",
+            )
+    plt.legend()
+    plt.title(variable_to_plot)
+    plt.show()

--- a/benchmark_utils/tuning_utils.py
+++ b/benchmark_utils/tuning_utils.py
@@ -1,0 +1,63 @@
+import json
+from collections import defaultdict
+import numpy as np
+import pandas as pd
+import os
+import pickle
+
+def format_and_save_tuning_results(tuning_results, variable: str, training_dataset : str):
+    """Format the tuning results and save them in the project directory."""
+    # format the results of all experiments
+    keys = list(tuning_results.results[0].metrics.keys())
+    all_metrics = keys[:keys.index("timestamp")]
+    all_results = []
+    for path in tuning_results.results:
+        # loop through every result of hyperparameters tried
+        path = path.path
+        hyperparameter = path.split("/")[6].split(f"{variable}=")[1].split("_")[0]
+        results = defaultdict(list)
+        with open(path+"/result.json", "r") as ff:
+            for line in ff:
+                # loop through every epoch of the training
+                data = json.loads(line.strip())
+                for key in all_metrics:
+                    if key in data:
+                        results[key].append(data[key])
+                    else:
+                        results[key].append(np.nan)
+        results = pd.DataFrame(results)
+        results["hyperparameter"] = hyperparameter
+        all_results.append(results)
+    all_results = pd.concat(all_results)
+
+    # save results and search space
+    save_dir = f"/home/owkin/project/mixupvi_tuning/{variable}/"
+    new_path = save_dir + f"{training_dataset}_dataset_{path.split('/')[5]}"
+    if not os.path.exists(save_dir):
+        # create a directory for the variable tuned
+        os.makedirs(save_dir)
+    if not os.path.exists(new_path):
+        # create a directory for the specific grid search performed
+        os.makedirs(new_path)
+    tuning_path = f"{new_path}/tuning_results.csv"
+    search_path = f"{new_path}/search_space.pkl"
+    all_results.to_csv(tuning_path)
+    best_hp = tuning_results.model_kwargs[variable] # best hp found by tuning main metric
+    search_space = tuning_results.search_space
+    search_space["best_hp"] = best_hp
+    with open(search_path, "wb") as ff:
+        pickle.dump(search_space, ff)
+    
+    return all_results, best_hp, tuning_path, search_path
+
+
+def read_tuning_results(tuning_path):
+    return pd.read_csv(tuning_path, index_col = 0)
+
+
+def read_search_space(search_path):
+    with open(search_path, "rb") as ff:
+        search_space = pickle.load(ff)
+    return search_space
+
+    

--- a/constants.py
+++ b/constants.py
@@ -3,16 +3,19 @@
 
 ## constants for run_mixupvi.py and benchmark_utils/training_utils.py
 # MixUpVI training constants
-SAVE_MODEL = True
-PATH = "/home/owkin/project/scvi_models/models/cti_linear_test"
+TUNE_MIXUPVI = True
+SAVE_MODEL = False
+PATH = "/home/owkin/project/scvi_models/models/test_run"
 TRAINING_DATASET = "CTI"  # ["CTI", "TOY", "CTI_PROCESSED", "CTI_RAW"]
 TRAINING_LOG = True # whether to log transform the data
 MAX_EPOCHS = 100
 BATCH_SIZE = 2048
-TRAIN_SIZE = 1.0 # as opposed to validation
+TRAIN_SIZE = 0.7 # as opposed to validation
+if TRAIN_SIZE < 1:
+    CHECK_VAL_EVERY_N_EPOCH = 1
 # MixUpVI specific constants and constraints
 TRAINING_CELL_TYPE_GROUP = (
-    "primary_groups"  # ["primary_groups", "precise_groups", "updated_granular_groups"]
+    "updated_granular_groups"  # ["primary_groups", "precise_groups", "updated_granular_groups"]
 )
 CONT_COV = None  # list of continuous covariates to include
 ENCODE_COVARIATES = False  # should be always False for now, we don't encode cat covar

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -8,6 +8,7 @@ import warnings
 
 from benchmark_utils import (
     fit_mixupvi,
+    tune_mixupvi,
     preprocess_scrna,
     add_cell_types_grouped,
     plot_metrics,
@@ -16,24 +17,32 @@ from benchmark_utils import (
     plot_reconstruction_loss,
     plot_kl_loss,
     plot_pearson_random,
+    compare_tuning_results,
+    read_tuning_results,
+    read_search_space,
 )
 from constants import (
+    TUNE_MIXUPVI,
     SAVE_MODEL,
     PATH,
     TRAINING_DATASET,
     TRAINING_LOG,
     TRAINING_CELL_TYPE_GROUP,
 )
+from tuning_configs import (
+    SEARCH_SPACE, TUNED_VARIABLES, NUM_SAMPLES, METRIC, ADDITIONAL_METRICS,
+)
 
 
 # %% Load scRNAseq dataset
 logger.info(f"Loading single-cell dataset: {TRAINING_DATASET} ...")
+cell_type = "cell_types_grouped"
 if TRAINING_DATASET == "TOY":
     adata_train = scvi.data.heart_cell_atlas_subsampled()
     preprocess_scrna(adata_train, keep_genes=1200, log=TRAINING_LOG)
-    CAT_COV = ["cell_type"]
+    cell_type = "cell_type"
 elif TRAINING_DATASET == "CTI":
-    adata = sc.read("/home/owkin/deepdeconv/data/cti_adata.h5ad")
+    adata = sc.read("/home/owkin/project/cti/cti_adata.h5ad")
     preprocess_scrna(adata,
                      keep_genes=2500,
                      log=TRAINING_LOG,
@@ -57,28 +66,88 @@ if TRAINING_DATASET != "TOY":
     adata, train_test_index = add_cell_types_grouped(adata, TRAINING_CELL_TYPE_GROUP)
     adata_train = adata[train_test_index["Train index"]]
     adata_test = adata[train_test_index["Test index"]]
-    CAT_COV = ["cell_types_grouped"]
 
 
 # %% Fit MixUpVI with hyperparameters defined in constants.py
 adata_train = adata_train.copy()
-model = fit_mixupvi(
-    adata_train, 
-    model_path=PATH, 
-    cell_type_group="cell_types_grouped", 
-    save_model=SAVE_MODEL
-)
+if TUNE_MIXUPVI:
+    all_results, best_hp, tuning_path, search_path = tune_mixupvi(
+        adata_train,
+        cell_type_group=cell_type,
+        search_space=SEARCH_SPACE,
+        metric=METRIC,
+        additional_metrics=ADDITIONAL_METRICS,
+        num_samples=NUM_SAMPLES,
+        training_dataset=TRAINING_DATASET,
+    )
+    model_history = all_results.loc[all_results.hyperparameter == best_hp] # plots for the best hp found by tuning
+else:
+    model = fit_mixupvi(
+        adata_train, 
+        model_path=PATH, 
+        cell_type_group=cell_type, 
+        save_model=SAVE_MODEL
+    )
+    model_history = model.history
 
 
-# %%
-# TODO: add option to load model
-n_epochs = len(model.history["train_loss_epoch"])
-plot_metrics(model.history, train=True, n_epochs=n_epochs)
-plot_metrics(model.history, train=False, n_epochs=n_epochs)
-plot_loss(model.history, n_epochs=n_epochs)
-plot_mixup_loss(model.history, n_epochs=n_epochs)
-plot_reconstruction_loss(model.history, n_epochs=n_epochs)
-plot_kl_loss(model.history, n_epochs=n_epochs)
-plot_pearson_random(model.history, train=True, n_epochs=n_epochs)
-plot_pearson_random(model.history, train=False, n_epochs=n_epochs)
+# %% Load model / results: Uncomment if not running previous cells
+# if TUNE_MIXUPVI:
+#     path = "/home/owkin/project/mixupvi_tuning/n_latent/TOY_dataset_tune_mixupvi_2023-12-15-11:15:32"
+#     all_results = read_tuning_results(f"{path}/tuning_results.csv")
+#     search_space = read_search_space(f"{path}/search_space.pkl")
+#     best_hp = search_space["best_hp"]
+#     model_history = all_results.loc[all_results.hyperparameter == best_hp] # plots for the best hp found by tuning
+# else:
+#     import torch
+#     path = "/home/owkin/project/scvi_models/models/toy_100_epochs"
+#     model = torch.load(f"{path}/model.pt")
+#     model_history = model["attr_dict"]["history_"]
+
+
+# %% Plots for a given model
+n_epochs = len(model_history["train_loss_epoch"])
+plot_metrics(model_history, train=True, n_epochs=n_epochs)
+plot_metrics(model_history, train=False, n_epochs=n_epochs)
+plot_loss(model_history, n_epochs=n_epochs)
+plot_mixup_loss(model_history, n_epochs=n_epochs)
+plot_reconstruction_loss(model_history, n_epochs=n_epochs)
+plot_kl_loss(model_history, n_epochs=n_epochs)
+plot_pearson_random(model_history, train=True, n_epochs=n_epochs)
+plot_pearson_random(model_history, train=False, n_epochs=n_epochs)
+
+
+# %% Plots to compare HPs
+if TUNE_MIXUPVI:
+    n_epochs = len(model_history["train_loss_epoch"])
+    tuned_variable = TUNED_VARIABLES[0]
+    hp_index_to_plot = [0, 1, 3, 4, 5] # only these index (of the HPs tried) will be plotted, for clearer visualisation
+    compare_tuning_results(
+        all_results, variable_to_plot="validation_loss", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results( # latent space pearson coeff
+        all_results, variable_to_plot="pearson_coeff_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results( # deconv pearson coefficient
+        all_results, variable_to_plot="pearson_coeff_deconv_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results( # deconv cosine similarity
+        all_results, variable_to_plot="cosine_similarity_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results(
+        all_results, variable_to_plot="mixup_penalty_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results(
+        all_results, variable_to_plot="reconstruction_loss_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
+    compare_tuning_results(
+        all_results, variable_to_plot="kl_local_validation", variable_tuned=tuned_variable,
+        n_epochs=n_epochs, hp_index_to_plot=hp_index_to_plot,
+    )
 # %%

--- a/run_pseudobulk_benchmark.py
+++ b/run_pseudobulk_benchmark.py
@@ -35,6 +35,7 @@ from benchmark_utils import (
 
 # %% Load scRNAseq dataset
 logger.info(f"Loading single-cell dataset: {BENCHMARK_DATASET} ...")
+cell_type = "cell_type_grouped"
 if BENCHMARK_DATASET == "TOY":
     raise NotImplementedError(
         "For now, the toy dataset cannot be used to run the benchmark because no "
@@ -42,6 +43,7 @@ if BENCHMARK_DATASET == "TOY":
     )
     # adata = scvi.data.heart_cell_atlas_subsampled()
     # preprocess_scrna(adata, keep_genes=1200, log=BENCHMARK_LOG)
+    # cell_type = "cell_type"
 elif BENCHMARK_DATASET == "CTI":
     adata = sc.read("/home/owkin/project/cti/cti_adata.h5ad")
     preprocess_scrna(adata,
@@ -102,7 +104,7 @@ if not ONLY_FIT_BASELINE_NNLS:
     model_path = f"models/{BENCHMARK_DATASET}_{BENCHMARK_CELL_TYPE_GROUP}_mixupvi.pkl"
     mixupvi_model = fit_mixupvi(adata_train,
                                 model_path,
-                                cell_type_group="cell_types_grouped",
+                                cell_type_group=cell_type,
                                 save_model=SAVE_MODEL,
                                 )
 else:

--- a/scvi/autotune/_defaults.py
+++ b/scvi/autotune/_defaults.py
@@ -3,6 +3,7 @@ from lightning.pytorch import LightningDataModule, LightningModule, Trainer
 from scvi import model
 from scvi.module.base import BaseModuleClass, JaxBaseModuleClass, PyroBaseModuleClass
 from scvi.train import TrainRunner
+from scvi.model.base import UnsupervisedTrainingMixin
 
 # colors for rich table columns
 COLORS = [
@@ -33,6 +34,7 @@ TUNABLE_TYPES = {
         LightningDataModule,
         Trainer,
         TrainRunner,
+        UnsupervisedTrainingMixin,
     ],
     "training_plan": [
         LightningModule,

--- a/scvi/model/_mixupvi.py
+++ b/scvi/model/_mixupvi.py
@@ -1,7 +1,9 @@
 import logging
+from typing import List, Optional, Union
 
 from ._scvi import SCVI
 from scvi.module import MixUpVAE
+from scvi.autotune._types import Tunable
 
 logger = logging.getLogger(__name__)
 
@@ -14,3 +16,29 @@ class MixUpVI(SCVI):
     """
 
     _module_cls = MixUpVAE
+
+    def train(self,
+        max_epochs: Tunable[Optional[int]] = None,
+        use_gpu: Optional[Union[str, int, bool]] = None,
+        accelerator: str = "auto",
+        devices: Union[int, List[int], str] = "auto",
+        train_size: Tunable[float] = 0.9,
+        validation_size: Optional[float] = None,
+        shuffle_set_split: bool = True,
+        batch_size: Tunable[int] = 128,
+        early_stopping: Tunable[bool] = False,
+        plan_kwargs: Optional[dict] = None,
+        **trainer_kwargs,):
+            super().train(
+                  max_epochs=max_epochs,
+                  use_gpu=use_gpu,
+                  accelerator=accelerator,
+                  devices=devices,
+                  train_size=train_size,
+                  validation_size=validation_size,
+                  shuffle_set_split=shuffle_set_split,
+                  batch_size=batch_size,
+                  early_stopping=early_stopping,
+                  plan_kwargs=plan_kwargs,
+                  **trainer_kwargs,
+            )

--- a/scvi/module/_mixupvae.py
+++ b/scvi/module/_mixupvae.py
@@ -152,11 +152,11 @@ class MixUpVAE(VAE):
         extra_encoder_kwargs: Optional[dict] = None,
         extra_decoder_kwargs: Optional[dict] = None,
         # MixUpVAE specific arguments
-        signature_type: str = "pre_encoded",
-        loss_computation: str = "latent_space",
-        pseudo_bulk: str = "pre_encoded",
-        encode_cont_covariates: bool = False,
-        mixup_penalty: str = "l2",
+        signature_type: Tunable[str] = "pre_encoded",
+        loss_computation: Tunable[str] = "latent_space",
+        pseudo_bulk: Tunable[str] = "pre_encoded",
+        encode_cont_covariates: Tunable[bool] = False,
+        mixup_penalty: Tunable[str] = "l2",
     ):
         super().__init__(
             n_input=n_input,

--- a/tuning_configs.py
+++ b/tuning_configs.py
@@ -1,0 +1,79 @@
+from ray import tune
+
+from constants import (
+    GROUPS, 
+    TRAINING_CELL_TYPE_GROUP,
+    USE_BATCH_NORM,
+    SIGNATURE_TYPE,
+    LOSS_COMPUTATION,
+    PSEUDO_BULK,
+    ENCODE_COVARIATES,
+    ENCODE_CONT_COVARIATES,
+    MIXUP_PENALTY,
+    DISPERSION,
+    GENE_LIKELIHOOD,
+    TRAIN_SIZE,
+    BATCH_SIZE,
+)
+
+
+### search space to define: the only thing to change
+
+example_search_space = {
+    "n_hidden": tune.choice([64, 128, 256]),
+    "n_layers": tune.choice([1, 2, 3]),
+    "lr": tune.loguniform(1e-4, 1e-2),
+}
+latent_space_search_space = {
+    "n_latent": tune.grid_search(
+        list(range(len(GROUPS[TRAINING_CELL_TYPE_GROUP]) - 1, 550, 20)) # from n cell types to n marker genes
+    )
+}
+SEARCH_SPACE = latent_space_search_space
+TUNED_VARIABLES = list(SEARCH_SPACE.keys())
+NUM_SAMPLES = 1 # will only perform once the gridsearch (useful to change if mix of grid and random search for instance)
+
+
+### add the model and training fixed hyperparameters 
+model_fixed_hps = {
+    "use_batch_norm": USE_BATCH_NORM,
+    "signature_type": SIGNATURE_TYPE,
+    "loss_computation": LOSS_COMPUTATION,
+    "pseudo_bulk": PSEUDO_BULK,
+    "encode_covariates": ENCODE_COVARIATES,
+    "encode_cont_covariates": ENCODE_CONT_COVARIATES,
+    "mixup_penalty": MIXUP_PENALTY,
+    "dispersion": DISPERSION,
+    "gene_likelihood": GENE_LIKELIHOOD,
+    "train_size": TRAIN_SIZE,
+    "batch_size": BATCH_SIZE,
+}
+for key in model_fixed_hps.keys():
+    # don't replace the search space by fixed hyperparemeter value
+    if key in TUNED_VARIABLES:
+        del model_fixed_hps[key]
+SEARCH_SPACE = SEARCH_SPACE | model_fixed_hps
+
+
+### all metrics to callback during tuning
+METRIC = "validation_loss"
+ADDITIONAL_METRICS = None
+ADDITIONAL_METRICS = [
+    # val metrics
+    "mixup_penalty_validation",
+    "reconstruction_loss_validation",
+    "kl_local_validation",
+    "pearson_coeff_validation",
+    "cosine_similarity_validation",
+    "pearson_coeff_deconv_validation",
+    "pearson_coeff_random_validation",
+    # train metrics
+    "train_loss_epoch",
+    "mixup_penalty_train",
+    "reconstruction_loss_train",
+    "kl_local_train",
+    "pearson_coeff_train",
+    "cosine_similarity_train",
+    "pearson_coeff_deconv_train",
+    "pearson_coeff_random_train",
+]


### PR DESCRIPTION
All the changes related to running a GridSearch tuning experiment on all kind of MixUpVI HPs. We can also choose to run other types of search (the API uses Ray tuner) later on.
The main changes are in our files, to integrate the tuning pipeline and plots in it smoothly. 
There are also changes in two files related to scvi's autotune module. Not pretty to change it directly, but I had no other choice.