### PR TITLE
MixUpDataSplitter following a Dirichlet distribution

### DIFF
--- a/benchmark_utils/dataset_utils.py
+++ b/benchmark_utils/dataset_utils.py
@@ -201,17 +201,13 @@ def create_dirichlet_pseudobulk_dataset(
     """
     logger.info("Creating dirichlet pseudobulk dataset...")
     seed = random.randint(0, 1000)
-    np.random.seed(seed)
+    random_state = np.random.RandomState(seed=seed)
     cell_types = adata.obs[cell_type_group].value_counts()
     if prior_alphas is None:
         prior_alphas = np.ones(len(cell_types))  # non-informative prior
-    likelihood_alphas = cell_types / len(
-        adata.obs
-    )  # multinomial likelihood (TO CHECK: maths behind average or sum for the likelihood)
-    alpha_posterior = (
-        prior_alphas + likelihood_alphas
-    )  # (TO CHECK: maths behind this simple addition)
-    posterior_dirichlet = np.random.dirichlet(alpha_posterior, n_sample)
+    likelihood_alphas = cell_types / adata.n_obs  # multinomial likelihood
+    alpha_posterior = prior_alphas + likelihood_alphas
+    posterior_dirichlet = random_state.dirichlet(alpha_posterior, n_sample)
     posterior_dirichlet = np.round(posterior_dirichlet * 1000)
     posterior_dirichlet = posterior_dirichlet.astype(np.int64)  # number of cells to sample
     groundtruth_fractions = posterior_dirichlet / posterior_dirichlet.sum(

--- a/constants.py
+++ b/constants.py
@@ -3,13 +3,13 @@
 
 ## constants for run_mixupvi.py and benchmark_utils/training_utils.py
 # MixUpVI training constants
-TUNE_MIXUPVI = False
+TUNE_MIXUPVI = True
 SAVE_MODEL = False
 PATH = "/home/owkin/project/scvi_models/models/test_run"
 TRAINING_DATASET = "CTI"  # ["CTI", "TOY", "CTI_PROCESSED", "CTI_RAW"]
 TRAINING_LOG = True # whether to log transform the data
 MAX_EPOCHS = 100
-BATCH_SIZE = 1024
+BATCH_SIZE = 2048
 TRAIN_SIZE = 0.7 # as opposed to validation
 if TRAIN_SIZE < 1:
     CHECK_VAL_EVERY_N_EPOCH = 1

--- a/constants.py
+++ b/constants.py
@@ -3,13 +3,13 @@
 
 ## constants for run_mixupvi.py and benchmark_utils/training_utils.py
 # MixUpVI training constants
-TUNE_MIXUPVI = True
+TUNE_MIXUPVI = False
 SAVE_MODEL = False
 PATH = "/home/owkin/project/scvi_models/models/test_run"
 TRAINING_DATASET = "CTI"  # ["CTI", "TOY", "CTI_PROCESSED", "CTI_RAW"]
 TRAINING_LOG = True # whether to log transform the data
 MAX_EPOCHS = 100
-BATCH_SIZE = 2048
+BATCH_SIZE = 1024
 TRAIN_SIZE = 0.7 # as opposed to validation
 if TRAIN_SIZE < 1:
     CHECK_VAL_EVERY_N_EPOCH = 1

--- a/scvi/dataloaders/__init__.py
+++ b/scvi/dataloaders/__init__.py
@@ -5,6 +5,7 @@ from ._ann_dataloader import AnnDataLoader
 from ._concat_dataloader import ConcatDataLoader
 from ._data_splitting import (
     DataSplitter,
+    MixUpDataSplitter,
     DeviceBackedDataSplitter,
     SemiSupervisedDataSplitter,
 )

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
 
-from scvi.dataloaders import DataSplitter
+from scvi.dataloaders import DataSplitter, MixUpDataSplitter
 from scvi.model._utils import get_max_epochs_heuristic
 from scvi.train import TrainingPlan, TrainRunner
 from scvi.utils._docstrings import devices_dsp
@@ -9,7 +9,8 @@ from scvi.utils._docstrings import devices_dsp
 class UnsupervisedTrainingMixin:
     """General purpose unsupervised train method."""
 
-    _data_splitter_cls = DataSplitter
+    # _data_splitter_cls = DataSplitter
+    _data_splitter_cls = MixUpDataSplitter
     _training_plan_cls = TrainingPlan
     _train_runner_cls = TrainRunner
 


### PR DESCRIPTION
This PR introduces the MixUpDataSplitter class, which essentially performs the train data splitting indices by sampling the cell type proportions for every batch following a Dirichlet distribution.

A few files of scvi itself have been changed to connect MixUpDataSplitter to the pipeline.
I created a new DataSplitter which is later used in the pipeline in the SequentialSampler class, but instead we could have kept the default DataSplitter and created a MixUpSampler.

Sample the cells without replacement following the dirichlet proportions. If there are not enough cells in some cell populations to sample without replacement for this batch, then :

- If reallocate is True, sample all cells of the minority population, and sample the rest in the other cell populations.
- If reallocate is False (default value), sample the cells of the minority population with replacement.

Thus, some cells may be shown several times during training between
batches (and within batches if reallocate is False) and some other won't
be shown. Rare cell types will be over-represented.
**We could also create artificially more batches with this technique.**

Connection to the whole scvi pipeline is not so easy. So as of now :

- When no cell types is given as categorical key to some-VI model, then the splitter will act as a classical random splitter.
- But if you want to use MixUpVI with a classical splitter, then you will need to comment to appropriate line of scvi.model.base.training_mixin.py
- Similarly, if you want to include some prior_alphas or to reallocate the minority population cells to other populations, then you will need to change the default value of these arguments in the setup() method of the MixUpDataSplitter class (in the path scvi.dataloaders._data_splitting.py).