### PR TITLE
Stability experiments : mutliple pseudobulks in the loss

### DIFF
--- a/benchmark_utils/__init__.py
+++ b/benchmark_utils/__init__.py
@@ -22,6 +22,7 @@ from .plotting_utils import (
     plot_deconv_results_group,
     plot_deconv_lineplot,
     plot_metrics,
+    plot_mse_mae_deconv,
     plot_loss,
     plot_mixup_loss,
     plot_reconstruction_loss,

--- a/benchmark_utils/plotting_utils.py
+++ b/benchmark_utils/plotting_utils.py
@@ -108,10 +108,6 @@ def plot_deconv_lineplot(results: Dict[int, pd.DataFrame],
     if save:
         plt.savefig(f"/home/owkin/project/plots/{filename}.png", dpi=300)
 
-
-
-
-
 def plot_metrics(model_history, train: bool = True, n_epochs: int = 100):
     """Plot the train or val metrics from training."""
     if train:
@@ -138,6 +134,26 @@ def plot_metrics(model_history, train: bool = True, n_epochs: int = 100):
     plt.title(f"{suffix} metrics")
     plt.show()
 
+def plot_mse_mae_deconv(model_history, train: bool = True, n_epochs: int = 100):
+    """Plot the train or val MSE and MAE deconv errors from training."""
+    if train:
+        suffix = "train"
+    else:
+        suffix = "validation"
+    plt.clf()
+    plt.plot(
+        range(n_epochs), 
+        model_history[f"mse_deconv_{suffix}"], 
+        label="Deconv MSE error",
+    )
+    plt.plot(
+        range(n_epochs), 
+        model_history[f"mae_deconv_{suffix}"], 
+        label="Deconv MAE error",
+    )
+    plt.legend()
+    plt.title(f"{suffix} errors")
+    plt.show()
 
 def plot_loss(model_history, n_epochs: int = 100):
     """Plot the train and val loss from training."""
@@ -152,7 +168,6 @@ def plot_loss(model_history, n_epochs: int = 100):
     plt.title("Loss epochs")
     plt.show()
 
-
 def plot_mixup_loss(model_history, n_epochs: int = 100):
     """Plot the train and val mixup loss from training."""
     plt.clf()
@@ -165,7 +180,6 @@ def plot_mixup_loss(model_history, n_epochs: int = 100):
     plt.legend()
     plt.title("Mixup loss epochs")
     plt.show()
-
 
 def plot_reconstruction_loss(model_history, n_epochs: int = 100):
     """Plot the train and val reconstruction loss from training."""
@@ -180,7 +194,6 @@ def plot_reconstruction_loss(model_history, n_epochs: int = 100):
     plt.title("Reconstruction loss epochs")
     plt.show()
 
-
 def plot_kl_loss(model_history, n_epochs: int = 100):
     """Plot the train and val KL loss from training."""
     plt.clf()
@@ -193,7 +206,6 @@ def plot_kl_loss(model_history, n_epochs: int = 100):
     plt.legend()
     plt.title("KL loss epochs")
     plt.show()
-
 
 def plot_pearson_random(model_history, train: bool = True, n_epochs: int = 100):
     """Plot the train or val random vs normal pearson deconv metrics from training."""
@@ -216,27 +228,19 @@ def plot_pearson_random(model_history, train: bool = True, n_epochs: int = 100):
     plt.title(f"{suffix} metrics")
     plt.show()
 
-
 def compare_tuning_results(
       all_results, variable_to_plot: str, variable_tuned: str, n_epochs: int = 100, hp_index_to_plot: list = None
 ):
     """Plot the train or val losses for a selection of hyperparameters."""
-    all_hp = all_results.hyperparameter.unique()
+    all_hp = all_results[variable_tuned].unique()
     if all_hp.dtype != "0":
         all_hp.sort()
-    if hp_index_to_plot is None:
-        # plot all HPs
-        hp_index_to_plot = range(len(all_hp))
-
-    plt.clf()
-    for i, hp in enumerate(all_hp):
-        if i in hp_index_to_plot:
-            model_history = all_results.loc[all_results.hyperparameter == hp]
-            plt.plot(
-                range(n_epochs),
-                model_history[variable_to_plot],
-                label=f"{variable_tuned}={hp}",
-            )
-    plt.legend()
-    plt.title(variable_to_plot)
+    if hp_index_to_plot is not None:
+        hp_to_plot = all_hp[hp_index_to_plot]
+        all_results = all_results.loc[all_results[variable_tuned].isin(hp_to_plot)]
+    
+    custom_palette = sns.color_palette("husl", n_colors=len(all_results[variable_tuned].unique()))
+    all_results["epoch"] = all_results.index
+    sns.set_theme(style="darkgrid")
+    sns.lineplot(x="epoch", y=variable_to_plot, hue=variable_tuned, ci="sd", data=all_results, err_style="bars", palette=custom_palette)
     plt.show()

--- a/benchmark_utils/training_utils.py
+++ b/benchmark_utils/training_utils.py
@@ -15,6 +15,8 @@ from constants import (
     MAX_EPOCHS,
     BATCH_SIZE,
     LATENT_SIZE,
+    N_PSEUDOBULKS,
+    N_CELLS_PER_PSEUDOBULK,
     TRAIN_SIZE,
     CHECK_VAL_EVERY_N_EPOCH,
     CONT_COV,
@@ -27,6 +29,8 @@ from constants import (
     MIXUP_PENALTY,
     DISPERSION,
     GENE_LIKELIHOOD,
+    MIXUP_PENATLY_AGGREGATION,
+    AVERAGE_VARIABLES_MIXUP_PENALTY,
 )
 
 def tune_mixupvi(adata: ad.AnnData,
@@ -82,8 +86,9 @@ def fit_mixupvi(adata: ad.AnnData,
             )
             mixupvi_model = scvi.model.MixUpVI(
                 adata,
+                n_pseudobulks=N_PSEUDOBULKS,
+                n_cells_per_pseudobulk=N_CELLS_PER_PSEUDOBULK,
                 n_latent=LATENT_SIZE,
-                n_cell_types=adata.obs[cell_type_group].nunique(),
                 use_batch_norm=USE_BATCH_NORM,
                 signature_type=SIGNATURE_TYPE,
                 loss_computation=LOSS_COMPUTATION,
@@ -92,6 +97,8 @@ def fit_mixupvi(adata: ad.AnnData,
                 mixup_penalty=MIXUP_PENALTY,
                 dispersion=DISPERSION,
                 gene_likelihood=GENE_LIKELIHOOD,
+                mixup_penalty_aggregation=MIXUP_PENATLY_AGGREGATION,
+                average_variables_mixup_penalty=AVERAGE_VARIABLES_MIXUP_PENALTY,
             )
             mixupvi_model.view_anndata_setup()
             mixupvi_model.train(

--- a/benchmark_utils/training_utils.py
+++ b/benchmark_utils/training_utils.py
@@ -31,6 +31,7 @@ from constants import (
     GENE_LIKELIHOOD,
     MIXUP_PENATLY_AGGREGATION,
     AVERAGE_VARIABLES_MIXUP_PENALTY,
+    SEED,
 )
 
 def tune_mixupvi(adata: ad.AnnData,
@@ -63,7 +64,7 @@ def tune_mixupvi(adata: ad.AnnData,
     )
 
     all_results, best_hp, tuning_path, search_path = format_and_save_tuning_results(
-        tuning_results, variable=TUNED_VARIABLES[0], training_dataset=training_dataset,
+        tuning_results, variables=TUNED_VARIABLES, training_dataset=training_dataset,
     )
 
     return all_results, best_hp, tuning_path, search_path
@@ -86,6 +87,7 @@ def fit_mixupvi(adata: ad.AnnData,
             )
             mixupvi_model = scvi.model.MixUpVI(
                 adata,
+                seed=SEED,
                 n_pseudobulks=N_PSEUDOBULKS,
                 n_cells_per_pseudobulk=N_CELLS_PER_PSEUDOBULK,
                 n_latent=LATENT_SIZE,

--- a/benchmark_utils/tuning_utils.py
+++ b/benchmark_utils/tuning_utils.py
@@ -5,16 +5,14 @@ import pandas as pd
 import os
 import pickle
 
-def format_and_save_tuning_results(tuning_results, variable: str, training_dataset : str):
+def format_and_save_tuning_results(tuning_results, variables: str, training_dataset : str):
     """Format the tuning results and save them in the project directory."""
     # format the results of all experiments
     keys = list(tuning_results.results[0].metrics.keys())
     all_metrics = keys[:keys.index("timestamp")]
     all_results = []
-    for path in tuning_results.results:
-        # loop through every result of hyperparameters tried
+    for path in tuning_results.results: # loop through every result of hyperparameters tried
         path = path.path
-        hyperparameter = path.split("/")[6].split(f"{variable}=")[1].split("-")[0][:-5]
         results = defaultdict(list)
         with open(path+"/result.json", "r") as ff:
             for line in ff:
@@ -26,14 +24,31 @@ def format_and_save_tuning_results(tuning_results, variable: str, training_datas
                     else:
                         results[key].append(np.nan)
         results = pd.DataFrame(results)
-        results["hyperparameter"] = hyperparameter
+        
+        hyperparameters = path.split("/")[6]
+        for i, variable in enumerate(variables):
+            hyperparameters=hyperparameters.split(f"{variable}=")[1]
+            if i < len(variables)-1:
+                value = hyperparameters.split(",")[0]
+            else:
+                value = hyperparameters.split("-")[0][:-5]
+            results[variable] = value
+        
         all_results.append(results)
+    
     all_results = pd.concat(all_results)
-    if all_results.hyperparameter.str.isnumeric().all():
-        all_results.hyperparameter = pd.to_numeric(all_results.hyperparameter)
-
+    best_hp = {}
+    for variable in variables:
+        if all_results[variable].str.isnumeric().all():
+            all_results[variable] = pd.to_numeric(all_results[variable])
+        if variable in tuning_results.model_kwargs:
+            best_hp[variable] = tuning_results.model_kwargs[variable] # best hp found by tuning main metric
+        elif variable in tuning_results.train_kwargs:
+            best_hp[variable] = tuning_results.train_kwargs[variable] # best hp found by tuning main metric
+        else:
+            best_hp[variable] = None
     # save results and search space
-    save_dir = f"/home/owkin/project/mixupvi_tuning/{variable}/"
+    save_dir = f"/home/owkin/project/mixupvi_tuning/{'-'.join(variables)}/"
     new_path = save_dir + f"{training_dataset}_dataset_{path.split('/')[5]}"
     if not os.path.exists(save_dir):
         # create a directory for the variable tuned
@@ -44,12 +59,7 @@ def format_and_save_tuning_results(tuning_results, variable: str, training_datas
     tuning_path = f"{new_path}/tuning_results.csv"
     search_path = f"{new_path}/search_space.pkl"
     all_results.to_csv(tuning_path)
-    if variable in tuning_results.model_kwargs:
-        best_hp = tuning_results.model_kwargs[variable] # best hp found by tuning main metric
-    elif variable in tuning_results.train_kwargs:
-        best_hp = tuning_results.train_kwargs[variable] # best hp found by tuning main metric
-    else:
-        best_hp = None
+
     search_space = tuning_results.search_space
     search_space["best_hp"] = best_hp
     with open(search_path, "wb") as ff:

--- a/benchmark_utils/tuning_utils.py
+++ b/benchmark_utils/tuning_utils.py
@@ -25,7 +25,7 @@ def format_and_save_tuning_results(tuning_results, variables: str, training_data
                         results[key].append(np.nan)
         results = pd.DataFrame(results)
         
-        hyperparameters = path.split("/")[6]
+        hyperparameters = path.split("/")[-1]
         for i, variable in enumerate(variables):
             hyperparameters=hyperparameters.split(f"{variable}=")[1]
             if i < len(variables)-1:

--- a/constants.py
+++ b/constants.py
@@ -33,7 +33,7 @@ SAVE_MODEL = False
 SEED = 0
 N_GENES = 3000 # number of input genes after preprocessing
 # MixUpVI training hyperparameters
-MAX_EPOCHS = 10
+MAX_EPOCHS = 100
 BATCH_SIZE = 2048
 TRAIN_SIZE = 0.7 # as opposed to validation
 CHECK_VAL_EVERY_N_EPOCH = None

--- a/constants.py
+++ b/constants.py
@@ -1,7 +1,7 @@
 """Constants and global variables to run the different deconv files."""
 
 ## constants for run_mixupvi.py
-TUNE_MIXUPVI = False
+TUNE_MIXUPVI = True
 TRAINING_DATASET = "CTI_PROCESSED"  # ["CTI", "TOY", "CTI_PROCESSED", "CTI_RAW"]
 TRAINING_CELL_TYPE_GROUP = (
     "updated_granular_groups"  # ["primary_groups", "precise_groups", "updated_granular_groups"]
@@ -24,10 +24,11 @@ BASELINES = ["nnls"] # "nnls", "TAPE", "Scaden"
 
 ## general mixupvi constants when training it or preprocessing data
 SAVE_MODEL = False
+SEED = 0
 N_GENES = 3000 # number of input genes after preprocessing
 # MixUpVI training hyperparameters
-MAX_EPOCHS = 100
-BATCH_SIZE = 4092
+MAX_EPOCHS = 10
+BATCH_SIZE = 2048
 TRAIN_SIZE = 0.7 # as opposed to validation
 CHECK_VAL_EVERY_N_EPOCH = None
 if TRAIN_SIZE < 1:
@@ -36,9 +37,9 @@ if TRAIN_SIZE < 1:
 N_PSEUDOBULKS = 1
 N_CELLS_PER_PSEUDOBULK = None # None (then will be batch size) or int (will cap at batch size)
 LATENT_SIZE = 30
-CONT_COV = ["_scvi_labels"]  # list of continuous covariates to include
-CAT_COV = ["donor_id", "assay"] # ["donor_id", "assay"]
-ENCODE_COVARIATES = True # whether to encode cont/cat covars (they are always decoded)
+CONT_COV = None  # None or list of continuous covariates to include
+CAT_COV = None # None or ["donor_id", "assay"]
+ENCODE_COVARIATES = False # whether to encode cont/cat covars (they are always decoded)
 LOSS_COMPUTATION = "latent_space"  # ["latent_space", "reconstructed_space"]
 PSEUDO_BULK = "pre_encoded"  # ["pre_encoded", "post_inference"]
 SIGNATURE_TYPE = "post_inference"  # ["pre_encoded", "post_inference"]

--- a/constants.py
+++ b/constants.py
@@ -33,17 +33,21 @@ CHECK_VAL_EVERY_N_EPOCH = None
 if TRAIN_SIZE < 1:
     CHECK_VAL_EVERY_N_EPOCH = 1
 # MixUpVI model hyperparameters
+N_PSEUDOBULKS = 1
+N_CELLS_PER_PSEUDOBULK = None # None (then will be batch size) or int (will cap at batch size)
+LATENT_SIZE = 30
 CONT_COV = ["_scvi_labels"]  # list of continuous covariates to include
 CAT_COV = ["donor_id", "assay"] # ["donor_id", "assay"]
 ENCODE_COVARIATES = True # whether to encode cont/cat covars (they are always decoded)
-SIGNATURE_TYPE = "post_inference"  # ["pre_encoded", "post_inference"]
-USE_BATCH_NORM = "none"  # ["encoder", "decoder", "none", "both"]
 LOSS_COMPUTATION = "latent_space"  # ["latent_space", "reconstructed_space"]
 PSEUDO_BULK = "pre_encoded"  # ["pre_encoded", "post_inference"]
+SIGNATURE_TYPE = "post_inference"  # ["pre_encoded", "post_inference"]
 MIXUP_PENALTY = "l2"  # ["l2", "kl"]
-DISPERSION = "gene"  # ["gene", "gene_cell"]
+DISPERSION = "gene"  # ["gene", "gene_label"]
 GENE_LIKELIHOOD = "zinb"  # ["zinb", "nb", "poisson"]
-LATENT_SIZE = 30
+MIXUP_PENATLY_AGGREGATION = "mean" # ["mean", "sum", "max"]
+AVERAGE_VARIABLES_MIXUP_PENALTY = False 
+USE_BATCH_NORM = "none"  # ["encoder", "decoder", "none", "both"]
 
 # different possibilities of cell groupings with the CTI dataset
 GROUPS = {

--- a/constants.py
+++ b/constants.py
@@ -33,8 +33,8 @@ CHECK_VAL_EVERY_N_EPOCH = None
 if TRAIN_SIZE < 1:
     CHECK_VAL_EVERY_N_EPOCH = 1
 # MixUpVI model hyperparameters
-CONT_COV = None  # list of continuous covariates to include
-CAT_COV = ["donor_id", "assay"] # list of categorical covariates to include
+CONT_COV = ["_scvi_labels"]  # list of continuous covariates to include
+CAT_COV = ["donor_id", "assay"] # ["donor_id", "assay"]
 ENCODE_COVARIATES = True # whether to encode cont/cat covars (they are always decoded)
 SIGNATURE_TYPE = "post_inference"  # ["pre_encoded", "post_inference"]
 USE_BATCH_NORM = "none"  # ["encoder", "decoder", "none", "both"]

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -95,19 +95,19 @@ else:
 
 
 # %% Load model / results: Uncomment if not running previous cells
-if TUNE_MIXUPVI:
-    path = "/home/owkin/project/mixupvi_tuning/n_latent-seed/CTI_PROCESSED_dataset_tune_mixupvi_2024-02-21-11:25:28"
-    all_results = read_tuning_results(f"{path}/tuning_results.csv")
-    search_space = read_search_space(f"{path}/search_space.pkl")
-    best_hp = search_space["best_hp"]
-    model_history = all_results.copy()
-    for variable in best_hp : 
-        # plots for the best hp found by tuning
-        model_history = model_history.loc[model_history[variable] == best_hp[variable]]
-else:
-    import torch
-    model = torch.load(f"{model_path}/model.pt")
-    model_history = model["attr_dict"]["history_"]
+# if TUNE_MIXUPVI:
+#     path = "/home/owkin/project/mixupvi_tuning/n_latent-seed/CTI_PROCESSED_dataset_tune_mixupvi_2024-02-21-11:25:28"
+#     all_results = read_tuning_results(f"{path}/tuning_results.csv")
+#     search_space = read_search_space(f"{path}/search_space.pkl")
+#     best_hp = search_space["best_hp"]
+#     model_history = all_results.copy()
+#     for variable in best_hp : 
+#         # plots for the best hp found by tuning
+#         model_history = model_history.loc[model_history[variable] == best_hp[variable]]
+# else:
+#     import torch
+#     model = torch.load(f"{model_path}/model.pt")
+#     model_history = model["attr_dict"]["history_"]
 
 
 # %% Plots for a given model

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -112,8 +112,6 @@ plot_loss(model_history, n_epochs=n_epochs)
 plot_mixup_loss(model_history, n_epochs=n_epochs)
 plot_reconstruction_loss(model_history, n_epochs=n_epochs)
 plot_kl_loss(model_history, n_epochs=n_epochs)
-plot_pearson_random(model_history, train=True, n_epochs=n_epochs)
-plot_pearson_random(model_history, train=False, n_epochs=n_epochs)
 
 
 # %% Plots to compare HPs

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -55,7 +55,7 @@ elif TRAINING_DATASET == "CTI_RAW":
     )
 elif TRAINING_DATASET == "CTI_PROCESSED":
     # Load processed for speed-up (already filtered, normalised, etc.)
-    adata = sc.read(f"/home/owkin/cti_data/processed/cti_processed_{N_GENES}.h5ad")
+    adata = sc.read(f"/home/owkin/project/data/cti_data/processed/cti_processed_{N_GENES}.h5ad")
 
 
 # %% Add cell types groups and split train/test

--- a/scvi/autotune/_manager.py
+++ b/scvi/autotune/_manager.py
@@ -158,7 +158,8 @@ class TunerManager:
                 "pearson_coeff_validation": "max",
                 "cosine_similarity_validation": "max",
                 "pearson_coeff_deconv_validation": "max",
-                "pearson_coeff_random_validation": "max",
+                "mse_deconv_validation": "min",
+                "mae_deconv_validation": "min",
                 # train metrics
                 "train_loss_epoch": "min",
                 "mixup_penalty_train": "min",
@@ -167,7 +168,8 @@ class TunerManager:
                 "pearson_coeff_train": "max",
                 "cosine_similarity_train": "max",
                 "pearson_coeff_deconv_train": "max",
-                "pearson_coeff_random_train": "max",
+                "mse_deconv_train": "min",
+                "mae_deconv_train": "min",
             }
 
         registry = {

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -223,7 +223,7 @@ class MixUpDataSplitter(DataSplitter):
         n_val = self.n_val
         indices = np.arange(self.adata_manager.adata.n_obs)
 
-        random_state = np.random.RandomState(seed=settings.seed) # settings.seed is None so new random state for each run
+        random_state = np.random.RandomState(seed=42) # settings.seed is None so new random state for each run
         if self.shuffle_set_split:
             indices = random_state.permutation(indices)
 

--- a/scvi/module/_mixupvae.py
+++ b/scvi/module/_mixupvae.py
@@ -378,6 +378,9 @@ class MixUpVAE(VAE):
                     j+=1
             categorical_input_copy = copy.deepcopy(categorical_input)
             categorical_pseudobulk_input_copy = copy.deepcopy(categorical_pseudobulk_input)
+        else :
+            categorical_input_copy = ()
+            categorical_pseudobulk_input_copy = ()
 
         # Encode covariates
         if not self.encode_covariates:
@@ -448,6 +451,7 @@ class MixUpVAE(VAE):
             "ql": ql,
             "library": library,
             "categorical_input": categorical_input_copy,
+            "one_hot_batch_index": one_hot_batch_index,
             # pseudobulk encodings
             "pseudobulk_indices": pseudobulk_indices,
             "z_pseudobulk": z_pseudobulk,
@@ -455,6 +459,8 @@ class MixUpVAE(VAE):
             "ql_pseudobulk": ql_pseudobulk,
             "library_pseudobulk": library_pseudobulk,
             "categorical_pseudobulk_input": categorical_pseudobulk_input_copy,
+            "cont_covs_pseudobulk": cont_covs_pseudobulk,
+            "one_hot_batch_index_pseudobulk": one_hot_batch_index_pseudobulk,
             # pure cell type signature encodings
             "z_signature": z_signature,
         }

--- a/scvi/module/_mixupvae.py
+++ b/scvi/module/_mixupvae.py
@@ -79,6 +79,11 @@ class MixUpVAE(VAE):
 
         * ``'normal'`` - Isotropic normal
         * ``'ln'`` - Logistic normal with normal params N(0, 1)
+    n_pseudobulks
+        Number of pseudobulks to create (i.e. number of MixUp losses to compute and average).
+    n_cells_per_pseudobulk
+        Number of cells to sample to create a pseudobulk sample. If None, the number 
+        of cells is equal to the batch size.
     signature_type
         One of
 
@@ -89,7 +94,6 @@ class MixUpVAE(VAE):
 
         * ``'latent_space'`` - Compute the MixUp loss in the latent space.
         * ``'reconstructed_space'`` - Compute the MixUp loss in the reconstructed space.
-        * ``'both'`` - Compute the MixUp loss in both latent and reconstructed space and sum them.
     pseudo_bulk
         One of
 
@@ -99,6 +103,16 @@ class MixUpVAE(VAE):
         Whether to concatenate covariates to expression in encoder
     mixup_penalty
         The loss to use to compare the average of encoded cell and the encoded pseudobulk.
+    mixup_penalty_aggregation
+        One of 
+
+        * ``'sum'`` - Sum the n_pseudobulk L2 losses
+        * ``'mean'`` - Average the n_pseudobulk L2 losses
+        * ``'max'`` - Take the max among the n_pseudobulk L2 losses
+    average_variables_mixup_penalty
+        Whether to average the mixup penalty across the different variables. When False, the values are just summed.
+        If the loss_computation is in the latent space, their are n_latent variables.
+        If inside the reconstructed space, their are n_input variables.
     deeply_inject_covariates
         Whether to concatenate covariates into output of hidden layers in encoder/decoder. This option
         only applies when `n_layers` > 1. The covariates are concatenated to the input of subsequent hidden layers.
@@ -157,10 +171,14 @@ class MixUpVAE(VAE):
         extra_encoder_kwargs: Optional[dict] = None,
         extra_decoder_kwargs: Optional[dict] = None,
         # MixUpVAE specific arguments
+        n_pseudobulks: Tunable[int] = 1,
+        n_cells_per_pseudobulk: Tunable[Optional[int]] = None,
         signature_type: Tunable[str] = "pre_encoded",
         loss_computation: Tunable[str] = "latent_space",
         pseudo_bulk: Tunable[str] = "pre_encoded",
         mixup_penalty: Tunable[str] = "l2",
+        mixup_penalty_aggregation: Tunable[str] = "sum",
+        average_variables_mixup_penalty: Tunable[bool] = False,
     ):
         super().__init__(
             n_input=n_input,
@@ -197,12 +215,16 @@ class MixUpVAE(VAE):
         )
 
         self.n_cell_types = n_cell_types
+        self.n_pseudobulks = n_pseudobulks
+        self.n_cells_per_pseudobulk = n_cells_per_pseudobulk
         self.signature_type = signature_type
         self.loss_computation = loss_computation
         self.pseudo_bulk = pseudo_bulk
         self.mixup_penalty = mixup_penalty
+        self.mixup_penalty_aggregation = mixup_penalty_aggregation
+        self.average_variables_mixup_penalty = average_variables_mixup_penalty
         self.z_signature = None
-        self.already_printed_warning = False
+        self.logger_messages = set()
 
     def _get_inference_input(self,tensors):
         batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
@@ -244,6 +266,7 @@ class MixUpVAE(VAE):
         categorical_input = inference_outputs["categorical_input"]
         library = inference_outputs["library"]
         library_pseudobulk = inference_outputs["library_pseudobulk"]
+        cont_covs_pseudobulk = inference_outputs["cont_covs_pseudobulk"]
         categorical_pseudobulk_input = inference_outputs["categorical_pseudobulk_input"]
         batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
         y = tensors[REGISTRY_KEYS.LABELS_KEY]
@@ -266,6 +289,7 @@ class MixUpVAE(VAE):
             "batch_index": batch_index,
             "y": y,
             "cont_covs": cont_covs,
+            "cont_covs_pseudobulk": cont_covs_pseudobulk,
             "categorical_input": categorical_input,
             "categorical_pseudobulk_input": categorical_pseudobulk_input,
             "size_factor": size_factor,
@@ -287,40 +311,55 @@ class MixUpVAE(VAE):
         Runs the inference (encoder) model.
         """
         x_ = x
-        x_pseudobulk_ = x.mean(axis=0).unsqueeze(0)
+
+        # create self.n_pseudobulks
+        if self.n_cells_per_pseudobulk is None:
+            n_cells_per_pseudobulk = x_.shape[0]
+        elif self.n_cells_per_pseudobulk > x_.shape[0]:
+            message = (
+            "n_cells_per_pseudobulk is larger than batch size. Redefining it to be "
+            "equal to batch size."
+            )
+            if message not in self.logger_messages:
+                # we only show it if larger than batch size (last batch of an epoch is
+                # usually smaller, we don't trigger a warning for this case).
+                logger.warn(message)
+            self.logger_messages.add(message)
+            n_cells_per_pseudobulk = x_.shape[0]
+        else:
+            n_cells_per_pseudobulk = self.n_cells_per_pseudobulk
+        random_state = np.random.RandomState(seed=42)
+        pseudobulk_indices = random_state.choice(
+            x_.shape[0],
+            size = (self.n_pseudobulks, n_cells_per_pseudobulk),
+            replace = True,
+        )
+        x_pseudobulk_ = x_[pseudobulk_indices, :].mean(axis=1)
 
         # create signature
         unique_indices, counts = y.unique(return_counts=True)
         proportions = counts.float() / len(y)
         # create training signature
-        x_signature_ = []
+        x_signature_mask = []
         for cell_type in unique_indices:
             idx = (y == cell_type).flatten()
-            x_pure = x_[idx, :].mean(axis=0)
-            x_signature_.append(x_pure)
-        x_signature_ = torch.stack(x_signature_, dim=0)
+            x_signature_mask.append(idx.tolist())
+        x_signature_mask = torch.Tensor(x_signature_mask).to(device="cuda")
+        x_signature_ = torch.matmul(x_signature_mask, x_)/counts.unsqueeze(-1)
 
         if self.use_observed_lib_size:
             library = torch.log(x.sum(axis=1)).unsqueeze(1)
-            library_pseudobulk = torch.log(x_pseudobulk_.sum())
+            library_pseudobulk = torch.log(x_pseudobulk_.sum(axis=1)).unsqueeze(1)
         if self.log_variational:
             x_ = torch.log(1 + x_)
             x_pseudobulk_ = torch.log(1 + x_pseudobulk_)
             x_signature_ = torch.log(1 + x_signature_)
         if cont_covs is not None and self.encode_covariates:
             encoder_input = torch.cat((x_, cont_covs), dim=-1)
-            encoder_pseudobulk_input = torch.cat(
-                (x_pseudobulk_, cont_covs.mean(axis=0).unsqueeze(1)), dim=-1
-            )
-            cont_covs_signature = []
-            for cell_type in unique_indices:
-                idx = (y == cell_type).flatten()
-                cont_covs_pure = cont_covs[idx, :].mean(axis=0)
-                cont_covs_signature.append(cont_covs_pure)
-            cont_covs_signature = torch.stack(cont_covs_signature, dim=0)
-            encoder_signature_input = torch.cat(
-                (x_signature_, cont_covs_signature), dim=-1
-            )
+            cont_covs_pseudobulk = cont_covs[pseudobulk_indices, :].mean(axis=1)
+            encoder_pseudobulk_input = torch.cat((x_pseudobulk_, cont_covs_pseudobulk), dim=-1)
+            cont_covs_signature = torch.matmul(x_signature_mask, cont_covs)/counts.unsqueeze(-1)
+            encoder_signature_input = torch.cat((x_signature_, cont_covs_signature), dim=-1)
         else:
             encoder_input = x_
             encoder_pseudobulk_input = x_pseudobulk_
@@ -336,14 +375,10 @@ class MixUpVAE(VAE):
                     # if n_cat == 0 then no batch index was given, so skip it
                     one_hot_cat_covs = one_hot(cat_covs[j], n_cat)
                     categorical_input.append(one_hot_cat_covs)
-                    ont_hot_cat_covs_pure = one_hot_cat_covs.mean(axis=0).resize(1,n_cat)
+                    ont_hot_cat_covs_pure = one_hot_cat_covs[pseudobulk_indices, :].mean(axis=1)
                     categorical_pseudobulk_input.append(ont_hot_cat_covs_pure)
-                    categorical_signature_input_temp = []
-                    for cell_type in unique_indices:
-                        idx = (y == cell_type).flatten()
-                        one_hot_cat_covs_pure = one_hot_cat_covs[idx, :].mean(axis=0)
-                        categorical_signature_input_temp.append(one_hot_cat_covs_pure)
-                    categorical_signature_input.append(torch.stack(categorical_signature_input_temp))
+                    one_hot_cat_covs_signature = torch.matmul(x_signature_mask, one_hot_cat_covs)/counts.unsqueeze(-1)
+                    categorical_signature_input.append(one_hot_cat_covs_signature)
                     j+=1
         else:
             categorical_input = ()
@@ -371,12 +406,7 @@ class MixUpVAE(VAE):
             )
         elif self.signature_type == "post_inference":
             # create signature matrix - inside the latent space
-            z_signature = []
-            for cell_type in unique_indices:
-                idx = (y == cell_type).flatten()
-                z_pure = z[idx, :].mean(axis=0)
-                z_signature.append(z_pure)
-            z_signature = torch.stack(z_signature, dim=0)
+            z_signature = torch.matmul(x_signature_mask, z)/counts.unsqueeze(-1)
 
         # library size
         ql = None
@@ -416,10 +446,12 @@ class MixUpVAE(VAE):
             "library": library,
             "categorical_input": categorical_input,
             # pseudobulk encodings
+            "pseudobulk_indices": pseudobulk_indices,
             "z_pseudobulk": z_pseudobulk,
             "qz_pseudobulk": qz_pseudobulk,
             "ql_pseudobulk": ql_pseudobulk,
             "library_pseudobulk": library_pseudobulk,
+            "cont_covs_pseudobulk": cont_covs_pseudobulk,
             "categorical_pseudobulk_input": categorical_pseudobulk_input,
             # pure cell type signature encodings
             "proportions": proportions,
@@ -437,6 +469,7 @@ class MixUpVAE(VAE):
         library_pseudobulk,
         batch_index,
         cont_covs=None,
+        cont_covs_pseudobulk=None,
         categorical_input=(),
         categorical_pseudobulk_input=(),
         size_factor=None,
@@ -446,6 +479,8 @@ class MixUpVAE(VAE):
         """Runs the generative model."""
         if self.pseudo_bulk == "post_inference":
             # create it from z by overwritting the one coming from inference
+            # TODO : if we realise we want to use this option, then z_pseudobulk is not 
+            # the simple mean anymore, it should use pseudobulk_indices from inference
             z_pseudobulk = z.mean(axis=0).unsqueeze(0)
 
         if cont_covs is None:
@@ -458,18 +493,17 @@ class MixUpVAE(VAE):
             decoder_pseudobulk_input = torch.cat(
                 [
                     z_pseudobulk,
-                    cont_covs.unsqueeze(0)
+                    cont_covs_pseudobulk.unsqueeze(0)
                     .expand(z_pseudobulk.size(0), -1, -1)
-                    .mean(axis=0)
-                    .unsqueeze(1),
                 ],
                 dim=-1,
             )
         else:
             decoder_input = torch.cat([z, cont_covs], dim=-1)
             decoder_pseudobulk_input = torch.cat(
-                [z_pseudobulk, cont_covs.mean(axis=0).unsqueeze(1)], dim=-1
+                [z_pseudobulk, cont_covs_pseudobulk], dim=-1
             )
+            
 
         if transform_batch is not None:
             batch_index = torch.ones_like(batch_index) * transform_batch
@@ -505,8 +539,12 @@ class MixUpVAE(VAE):
             px_r = F.linear(
                 one_hot(y, self.n_labels), self.px_r
             )  # px_r gets transposed - last dimension is nb genes
+            px_pseudobulk_r = F.linear(
+                one_hot(y, self.n_labels), self.px_r
+            )  # should we create self.px_pseudobulk_r ?
         elif self.dispersion == "gene-batch":
             px_r = F.linear(one_hot(batch_index, self.n_batch), self.px_r)
+            px_pseudobulk_r = F.linear(one_hot(batch_index, self.n_batch), self.px_r)
         elif self.dispersion == "gene":
             px_r = self.px_r
             px_pseudobulk_r = self.px_r
@@ -525,7 +563,6 @@ class MixUpVAE(VAE):
             px = NegativeBinomial(mu=px_rate, theta=px_r, scale=px_scale)
         elif self.gene_likelihood == "poisson":
             px = Poisson(px_rate, scale=px_scale)
-        # pseudobulk gene likelihood
         px_pseudobulk = NegativeBinomial(
             mu=px_pseudobulk_rate, theta=px_pseudobulk_r, scale=px_pseudobulk_scale
         )
@@ -644,58 +681,71 @@ class MixUpVAE(VAE):
 
     def get_mix_up_loss(self, inference_outputs, generative_outputs):
         """Compute L2 loss or KL divergence between single cells average and pseudobulk."""
+        pseudobulk_indices = inference_outputs["pseudobulk_indices"]
         if self.mixup_penalty == "l2":
             # l2 penalty between mean(cells) and pseudobulk
             if self.loss_computation == "latent_space":
-                mean_single_cells = torch.mean(inference_outputs["z"], axis=0)
+                mean_single_cells = inference_outputs["z"][pseudobulk_indices, :].mean(axis=1)
                 pseudobulk = inference_outputs["z_pseudobulk"]
             elif self.loss_computation == "reconstructed_space":
-                if not self.already_printed_warning:
-                    logger.warn(
-                        "Sampling with the reparametrization trick is not possible with"
-                        " NegativeBinomial or ZeroInflatedNegativeBinomial "
-                        "distributions. Therefore, the MixUp penalty will not be used "
-                        "during gradient descent."
-                    )
-                    self.already_printed_warning = True
-                mean_single_cells = torch.mean(
-                    generative_outputs["px"].sample(), axis=0
+                message = (
+                    "Sampling with the reparametrization trick is not possible with"
+                    "discrete probability distribution like Poisson, NB, ZINB. "
+                    "Therefore, the MixUp penalty will the rate (i.e. mean) of  the"
+                    "distribution instead."
                 )
-                pseudobulk = generative_outputs["px_pseudobulk"].sample()
-            mixup_penalty = torch.sum((pseudobulk - mean_single_cells) ** 2)
+                if message not in self.logger_messages:
+                    logger.warn(message)
+                    self.logger_messages.add(message)
+                if self.gene_likelihood in ("zinb", "nb"):
+                    mean_single_cells = generative_outputs["px"].mu[pseudobulk_indices, :].mean(axis=1)
+                    pseudobulk = generative_outputs["px_pseudobulk"].mu
+                elif self.gene_likelihood == "poisson":
+                    mean_single_cells = generative_outputs["px"].rate[pseudobulk_indices, :].mean(axis=1)
+                    pseudobulk = generative_outputs["px_pseudobulk"].rate
+            mixup_penalty = torch.sum((pseudobulk - mean_single_cells) ** 2, axis=1)
+            if self.average_variables_mixup_penalty:
+                mixup_penalty /= mean_single_cells.shape[1]
         elif self.mixup_penalty == "kl":
             # kl of mean(cells) compared to reference pseudobulk
             if self.loss_computation == "latent_space":
-                mean_averaged_cells = inference_outputs["qz"].mean.mean(axis=0)
-                std_averaged_cells = inference_outputs["qz"].variance.sum(
-                    axis=0
-                ).sqrt() / len(inference_outputs["qz"].loc)
+                mean_averaged_cells = inference_outputs["qz"].mean[pseudobulk_indices, :].mean(axis=1)
+                std_averaged_cells = inference_outputs["qz"].variance[pseudobulk_indices, :].sum(
+                    axis=1
+                ).sqrt() / pseudobulk_indices.shape[1]
                 averaged_cells_distrib = Normal(mean_averaged_cells, std_averaged_cells)
+                pseudobulk_reference_distrib = inference_outputs["qz_pseudobulk"]
             elif self.loss_computation == "reconstructed_space":
-                distrib_type = str(generative_outputs["px"].__class__).split(".")[-1][
-                    :-2
-                ]
-                if distrib_type == "Poisson":
-                    rate_averaged_cells = generative_outputs["px"].rate.mean(axis=0)
-                    averaged_cells_distrib = Poisson(rate_averaged_cells)
-                elif self.dispersion != "gene":
-                    raise NotImplementedError(
-                        "The parameters of the sum of independant variables following "
-                        "negative binomials with varying dispersion is not computable yet."
-                    )
-                elif distrib_type == "NegativeBinomial":
-                    # only works because dispersion is constant across cells
-                    mean_averaged_cells = generative_outputs["px"].mu.mean(axis=0)
-                    averaged_cells_distrib = NegativeBinomial(rate_averaged_cells)
-                elif self.gene_likelihood == "ZeroInflatedNegativeBinomial":
-                    # not yet implemented because of the zero inflation
-                    raise NotImplementedError(
-                        "The parameters of the sum of independant variables following "
-                        "zero-inflated negative binomials is not computable yet."
-                    )
+                raise NotImplementedError(
+                    "KL divergence is not implemented for other distributions than Normal."
+                )
+                # if self.gene_likelihood == "poisson":
+                #     rate_averaged_cells = generative_outputs["px"].rate[pseudobulk_indices, :].mean(axis=1)
+                #     averaged_cells_distrib = Poisson(rate_averaged_cells)
+                # elif self.dispersion != "gene":
+                #     raise NotImplementedError(
+                #         "The parameters of the sum of independant variables following "
+                #         "negative binomials with varying dispersion is not computable yet."
+                #     )
+                # elif self.gene_likelihood == "nb":
+                #     # only works because dispersion is constant across cells
+                #     mean_averaged_cells = generative_outputs["px"].mu[pseudobulk_indices, :].mean(axis=1)
+                #     dispersion_averaged_cells = generative_outputs["px"].theta[pseudobulk_indices, :].mean(axis=1)
+                #     averaged_cells_distrib = NegativeBinomial(mu=mean_averaged_cells, theta=dispersion_averaged_cells)
+                # elif self.gene_likelihood == "zinb":
+                #     # not yet implemented because of the zero inflation
+                #     raise NotImplementedError(
+                #         "The parameters of the sum of independant variables following "
+                #         "zero-inflated negative binomials is not computable yet."
+                #     )
+                # pseudobulk_reference_distrib = generative_outputs["px_pseudobulk"]
             mixup_penalty = kl(
-                averaged_cells_distrib, generative_outputs["px_pseudobulk"]
-            ).sum(
-                dim=-1
-            )  # should it be negative in the case of kl?
+                averaged_cells_distrib, pseudobulk_reference_distrib
+            ).sum(dim=-1)
+        if self.mixup_penalty_aggregation == "max":
+            mixup_penalty = mixup_penalty.max()
+        else :
+            mixup_penalty = torch.sum(mixup_penalty)
+            if self.mixup_penalty_aggregation == "mean":
+                mixup_penalty /= mean_single_cells.shape[0]
         return mixup_penalty

--- a/scvi/module/_utils.py
+++ b/scvi/module/_utils.py
@@ -81,13 +81,14 @@ def create_random_proportion(
     return np.random.permutation(proportion_vector)
 
 
-def get_pearsonr_torch(x, y):
+def get_mean_pearsonr_torch(x, y):
     """
     Mimics `scipy.stats.pearsonr`
+    Rewritten to adapt to 2D tensors, to compute the mean of the 1D correlations along the first axis.
     Arguments
     ---------
-    x : 1D torch.Tensor
-    y : 1D torch.Tensor
+    x : 2D torch.Tensor
+    y : 2D torch.Tensor
     Returns
     -------
     r_val : float
@@ -105,14 +106,14 @@ def get_pearsonr_torch(x, y):
         >>> th_corr = pearsonr(torch.from_numpy(x), torch.from_numpy(y))
         >>> np.allclose(sp_corr, th_corr)
     """
-    mean_x = torch.mean(x)
-    mean_y = torch.mean(y)
+    mean_x = torch.mean(x, axis=1).unsqueeze(dim=1)
+    mean_y = torch.mean(y, axis=1).unsqueeze(dim=1)
     xm = x.sub(mean_x)
     ym = y.sub(mean_y)
-    r_num = xm.dot(ym)
-    r_den = torch.norm(xm, 2) * torch.norm(ym, 2)
+    r_num = (xm*ym).sum(dim=1)
+    r_den = torch.norm(xm, p=2, dim=1) * torch.norm(ym, p=2, dim=1)
     r_val = r_num / r_den
-    return r_val
+    return torch.mean(r_val)
 
 
 def run_incompatible_value_checks(

--- a/scvi/module/_utils.py
+++ b/scvi/module/_utils.py
@@ -81,6 +81,33 @@ def create_random_proportion(
     return np.random.permutation(proportion_vector)
 
 
+def compute_ground_truth_proportions(y_pseudobulk, n_labels, n_cells_per_pseudobulk):
+    """Compute the ground truth cell type proportions for each pseudobulk of the batch."""
+    all_proportions = []
+    for ground_truth in y_pseudobulk:
+        unique_indices, counts = ground_truth.unique(return_counts=True)
+        if len(counts) < n_labels:
+            # then not all labels are present in pseudobulk, but we need to specify these proportions of 0
+            unique_indices = unique_indices.int().tolist()
+            counts =  [counts[unique_indices.index(j)].item() if j in unique_indices else 0 for j in range(n_labels)]
+            counts = torch.tensor(counts).to(device="cuda")
+        proportions = counts.float() / n_cells_per_pseudobulk
+        all_proportions.append(proportions)
+    return all_proportions
+
+
+def compute_signature(y, x_):
+    """Compute the signature matrix and signature matrix mask of the batch."""
+    x_signature_mask = []
+    unique_indices, counts = y.unique(return_counts=True)
+    for cell_type in unique_indices:
+        idx = (y == cell_type).flatten()
+        x_signature_mask.append(idx.tolist())
+    x_signature_mask = torch.Tensor(x_signature_mask).to(device="cuda")
+    x_signature_ = torch.matmul(x_signature_mask, x_)/counts.unsqueeze(-1)
+    return counts, x_signature_mask, x_signature_
+
+
 def get_mean_pearsonr_torch(x, y):
     """
     Mimics `scipy.stats.pearsonr`

--- a/tuning_configs.py
+++ b/tuning_configs.py
@@ -18,6 +18,7 @@ from constants import (
     N_CELLS_PER_PSEUDOBULK,
     MIXUP_PENATLY_AGGREGATION,
     AVERAGE_VARIABLES_MIXUP_PENALTY,
+    SEED,
 )
 
 
@@ -27,6 +28,15 @@ example_search_space = {
     "n_hidden": tune.choice([64, 128, 256]),
     "n_layers": tune.choice([1, 2, 3]),
     "lr": tune.loguniform(1e-4, 1e-2),
+}
+repeat_with_several_seeds = {
+    "seed": tune.grid_search(
+        [0, 3, 8, 12, 23]
+    )
+}
+example_with_several_seeds = {
+    "n_latent": tune.grid_search([30, 100]),
+    "seed": tune.grid_search([3, 8, 12])
 }
 latent_space_search_space = {
     "n_latent": tune.grid_search(
@@ -67,7 +77,7 @@ n_hidden_search_space = {
 n_layers_search_space = {
     "n_layers": tune.grid_search([1, 2, 3])
 }
-SEARCH_SPACE = n_layers_search_space
+SEARCH_SPACE = example_with_several_seeds
 TUNED_VARIABLES = list(SEARCH_SPACE.keys())
 NUM_SAMPLES = 1 # will only perform once the gridsearch (useful to change if mix of grid and random search for instance)
 
@@ -89,6 +99,7 @@ model_fixed_hps = {
     "n_cells_per_pseudobulk": N_CELLS_PER_PSEUDOBULK,
     "mixup_penalty_aggregation": MIXUP_PENATLY_AGGREGATION,
     "average_variables_mixup_penalty": AVERAGE_VARIABLES_MIXUP_PENALTY,
+    "seed": SEED,
 }
 for key in list(model_fixed_hps):
     # don't replace the search space by fixed hyperparemeter value
@@ -108,7 +119,8 @@ ADDITIONAL_METRICS = [
     "pearson_coeff_validation",
     "cosine_similarity_validation",
     "pearson_coeff_deconv_validation",
-    "pearson_coeff_random_validation",
+    "mse_deconv_validation",
+    "mae_deconv_validation",
     # train metrics
     "train_loss_epoch",
     "mixup_penalty_train",
@@ -117,5 +129,6 @@ ADDITIONAL_METRICS = [
     "pearson_coeff_train",
     "cosine_similarity_train",
     "pearson_coeff_deconv_train",
-    "pearson_coeff_random_train",
+    "mse_deconv_train",
+    "mae_deconv_train",
 ]

--- a/tuning_configs.py
+++ b/tuning_configs.py
@@ -77,7 +77,12 @@ n_hidden_search_space = {
 n_layers_search_space = {
     "n_layers": tune.grid_search([1, 2, 3])
 }
-SEARCH_SPACE = example_with_several_seeds
+n_pseudobulks_search_space = {
+    "n_pseudobulks": tune.grid_search([1, 5, 10, 30, 50, 100]),
+    "seed": tune.grid_search([3, 8, 12])
+    # "seed": tune.grid_search([3, 8, 12, 23, 42])
+}
+SEARCH_SPACE = n_pseudobulks_search_space
 TUNED_VARIABLES = list(SEARCH_SPACE.keys())
 NUM_SAMPLES = 1 # will only perform once the gridsearch (useful to change if mix of grid and random search for instance)
 

--- a/tuning_configs.py
+++ b/tuning_configs.py
@@ -14,6 +14,10 @@ from constants import (
     TRAIN_SIZE,
     BATCH_SIZE,
     LATENT_SIZE,
+    N_PSEUDOBULKS,
+    N_CELLS_PER_PSEUDOBULK,
+    MIXUP_PENATLY_AGGREGATION,
+    AVERAGE_VARIABLES_MIXUP_PENALTY,
 )
 
 
@@ -81,7 +85,10 @@ model_fixed_hps = {
     "train_size": TRAIN_SIZE,
     "batch_size": BATCH_SIZE,
     "n_latent": LATENT_SIZE,
-    "n_cell_types": len(GROUPS[TRAINING_CELL_TYPE_GROUP]) - 1,
+    "n_pseudobulks": N_PSEUDOBULKS,
+    "n_cells_per_pseudobulk": N_CELLS_PER_PSEUDOBULK,
+    "mixup_penalty_aggregation": MIXUP_PENATLY_AGGREGATION,
+    "average_variables_mixup_penalty": AVERAGE_VARIABLES_MIXUP_PENALTY,
 }
 for key in list(model_fixed_hps):
     # don't replace the search space by fixed hyperparemeter value


### PR DESCRIPTION
This PR was created to understand why the model metrics were not reproducible through different runs, which was a flaw to choose our hyperparameter values when they were not ordinal.
To do so, several changes were implemented:
1. Fix the train/val split seed to 42.
2. Sample several pseudobulks from a given batch in the training of MixUpVI, to show more than one pseudobulk per epoch (indeed, the classical ELBO loss is computed over every cell per batch, not just one, so maybe a similar idea for the pseudobulk loss would help it and make the model more stable). See below for more info.
3. Fix the torch seed to a value defined in `constants.py`. This allows to fix weight initialisation, the optimizer, and the sampling from the latent space. **Consequently, one can now tune the hyperparameters over several torch seeds, and plot the tuning graphs with a confidence interval due to the different seeds tried.**

To try and make the model more stable over different runs, and also as a general improvement idea, this PR allows to sample several pseudobulks in a given sample.. Therefore several attributes are now created and tunable : 
1. n_pseudobulks : how many pseudobulks are created in the batch
4. n_cells_per_pseudobulk : how many bootstrapped cells should every pseudobulk be composed of. Can be a maximum of n_batch cells.
5. mixup_penalty_aggregation : now there are as many penalty values as there are pseudobulks. How can to only get a scaler ? Either take the maximum value across pseudobulks, or the average, or the sum.
6. average_variables_mixup_penalty: whether to average (or sum if False) the penalty values across variables. Variables are just a few if the loss is computed in the latent space, therefore simply summing can be good. But inside the reconstructed space, variables are as many as n_input genes, so averaging can be better there.

_Finally, it is now possible to compute the L2 loss inside the reconstructed space, because instead of sampling a discrete distribution (making the reparametrization trick impossible), we just use the mean of the reconstructed distribution for the L2 loss._