### PR TITLE
fix mixupvi performances in benchmark

### DIFF
--- a/benchmark_utils/latent_signature_utils.py
+++ b/benchmark_utils/latent_signature_utils.py
@@ -12,6 +12,7 @@ from .dataset_utils import create_anndata_pseudobulk
 
 def create_latent_signature(
     adata: ad.AnnData,
+    use_mixupvi: bool = False,
     repeats: int = 1,
     average_all_cells: bool = True,
     sc_per_pseudobulk: int = 3000,
@@ -109,16 +110,21 @@ def create_latent_signature(
                     assert (
                         count_key is not None
                     ), "Must give a count key if aggregating before embedding."
-
-                    pseudobulk = (
-                        adata_sampled.layers[count_key].mean(axis=0).reshape(1, -1)
-                    )  # .astype(int).astype(numpy.float32)
-                    adata_pseudobulk = create_anndata_pseudobulk(
-                        adata_sampled, pseudobulk
-                    )
-                    result = model.get_latent_representation(adata_pseudobulk).reshape(
-                        -1
-                    )
+                    
+                    if use_mixupvi:
+                        result = model.get_latent_representation(
+                            adata_sampled, get_pseudobulk=True
+                        ).reshape(-1)
+                    else:
+                        pseudobulk = (
+                            adata_sampled.layers[count_key].mean(axis=0).reshape(1, -1)
+                        )  # .astype(int).astype(numpy.float32)
+                        adata_pseudobulk = create_anndata_pseudobulk(
+                            adata_sampled, pseudobulk
+                        )
+                        result = model.get_latent_representation(adata_pseudobulk).reshape(
+                            -1
+                        )
                 else:
                     raise ValueError(
                         "Only pre-encoded signatures are supported for now."

--- a/benchmark_utils/sanity_checks_utils.py
+++ b/benchmark_utils/sanity_checks_utils.py
@@ -160,6 +160,7 @@ def run_sanity_check(
     adata_train: ad.AnnData,
     adata_pseudobulk_test_counts: ad.AnnData,
     adata_pseudobulk_test_rc: ad.AnnData,
+    all_adata_samples_test: List[ad.AnnData],
     df_proportions_test: pd.DataFrame,
     signature: pd.DataFrame,
     intersection: List[str],
@@ -260,14 +261,20 @@ def run_sanity_check(
             df_test_correlations.loc[:, "DestVI"] = correlations.values
             df_test_group_correlations.loc[:, "DestVI"] = group_correlations.values
         else:
+            use_mixupvi=False
+            if model == "MixupVI":
+                use_mixupvi=True
             adata_latent_signature = create_latent_signature(
                 adata=adata_train,
                 model=generative_models[model],
+                use_mixupvi=use_mixupvi,
                 average_all_cells = True,
                 sc_per_pseudobulk=10000,
             )
             deconv_results = perform_latent_deconv(
                 adata_pseudobulk=adata_pseudobulk_test_counts,
+                all_adata_samples=all_adata_samples_test,
+                use_mixupvi=use_mixupvi,
                 adata_latent_signature=adata_latent_signature,
                 model=generative_models[model],
             )

--- a/constants.py
+++ b/constants.py
@@ -19,11 +19,12 @@ BENCHMARK_DATASET = "CTI"  # ["CTI", "TOY", "CTI_PROCESSED", "CTI_RAW"]
 N_SAMPLES = 500 # number of pseudbulk samples to create and assess for deconvolution
 GENERATIVE_MODELS = ["MixupVI"] #, "DestVI"] # "scVI", "CondscVI", "DestVI"
 # GENERATIVE_MODELS = [] # if only want baselines
-BASELINES = ["nnls", "TAPE", "Scaden"] # "nnls", "TAPE", "Scaden"
+BASELINES = ["nnls"] # "nnls", "TAPE", "Scaden"
 # BASELINES = ["nnls"] # if only want nnls
 
 ## general mixupvi constants when training it or preprocessing data
 SAVE_MODEL = False
+N_INPUT = 2500 # number of input genes
 # MixUpVI training hyperparameters
 MAX_EPOCHS = 100
 BATCH_SIZE = 1024

--- a/constants.py
+++ b/constants.py
@@ -24,7 +24,7 @@ BASELINES = ["nnls"] # "nnls", "TAPE", "Scaden"
 
 ## general mixupvi constants when training it or preprocessing data
 SAVE_MODEL = False
-N_INPUT = 2500 # number of input genes
+N_GENES = 3000 # number of input genes after preprocessing
 # MixUpVI training hyperparameters
 MAX_EPOCHS = 100
 BATCH_SIZE = 1024

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -24,6 +24,7 @@ from benchmark_utils import (
 from constants import (
     TUNE_MIXUPVI,
     SAVE_MODEL,
+    N_INPUT,
     TRAINING_DATASET,
     TRAINING_CELL_TYPE_GROUP,
 )
@@ -42,19 +43,19 @@ if TRAINING_DATASET == "TOY":
 elif TRAINING_DATASET == "CTI":
     adata = sc.read("/home/owkin/project/cti/cti_adata.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=2500,
+                     keep_genes=N_INPUT,
                      batch_key="donor_id")
 elif TRAINING_DATASET == "CTI_RAW":
     warnings.warn("The raw data of this adata is on adata.raw.X, but the normalised "
                   "adata.X will be used here")
     adata = sc.read("/home/owkin/data/cross-tissue/omics/raw/local.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=2500,
+                     keep_genes=N_INPUT,
                      batch_key="donor_id",
     )
 elif TRAINING_DATASET == "CTI_PROCESSED":
     # Load processed for speed-up (already filtered, normalised, etc.)
-    adata = sc.read("/home/owkin/cti_data/processed/cti_processed_2500.h5ad")
+    adata = sc.read(f"/home/owkin/cti_data/processed/cti_processed_{N_INPUT}.h5ad")
 
 
 # %% Add cell types groups and split train/test
@@ -79,7 +80,7 @@ if TUNE_MIXUPVI:
     model_history = all_results.loc[all_results.hyperparameter == best_hp] # plots for the best hp found by tuning
     search_space = read_search_space(search_path)
 else:
-    model_path = f"project/models/{TRAINING_DATASET}_{TRAINING_CELL_TYPE_GROUP}_mixupvi.pkl"
+    model_path = f"project/models/{TRAINING_DATASET}_{TRAINING_CELL_TYPE_GROUP}_{N_INPUT}_mixupvi.pkl"
     model = fit_mixupvi(
         adata_train,
         model_path=model_path,

--- a/run_mixupvi.py
+++ b/run_mixupvi.py
@@ -24,7 +24,7 @@ from benchmark_utils import (
 from constants import (
     TUNE_MIXUPVI,
     SAVE_MODEL,
-    N_INPUT,
+    N_GENES,
     TRAINING_DATASET,
     TRAINING_CELL_TYPE_GROUP,
 )
@@ -43,19 +43,19 @@ if TRAINING_DATASET == "TOY":
 elif TRAINING_DATASET == "CTI":
     adata = sc.read("/home/owkin/project/cti/cti_adata.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=N_INPUT,
+                     keep_genes=N_GENES,
                      batch_key="donor_id")
 elif TRAINING_DATASET == "CTI_RAW":
     warnings.warn("The raw data of this adata is on adata.raw.X, but the normalised "
                   "adata.X will be used here")
     adata = sc.read("/home/owkin/data/cross-tissue/omics/raw/local.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=N_INPUT,
+                     keep_genes=N_GENES,
                      batch_key="donor_id",
     )
 elif TRAINING_DATASET == "CTI_PROCESSED":
     # Load processed for speed-up (already filtered, normalised, etc.)
-    adata = sc.read(f"/home/owkin/cti_data/processed/cti_processed_{N_INPUT}.h5ad")
+    adata = sc.read(f"/home/owkin/cti_data/processed/cti_processed_{N_GENES}.h5ad")
 
 
 # %% Add cell types groups and split train/test
@@ -80,7 +80,7 @@ if TUNE_MIXUPVI:
     model_history = all_results.loc[all_results.hyperparameter == best_hp] # plots for the best hp found by tuning
     search_space = read_search_space(search_path)
 else:
-    model_path = f"project/models/{TRAINING_DATASET}_{TRAINING_CELL_TYPE_GROUP}_{N_INPUT}_mixupvi.pkl"
+    model_path = f"project/models/{TRAINING_DATASET}_{TRAINING_CELL_TYPE_GROUP}_{N_GENES}_mixupvi.pkl"
     model = fit_mixupvi(
         adata_train,
         model_path=model_path,

--- a/run_pseudobulk_benchmark.py
+++ b/run_pseudobulk_benchmark.py
@@ -9,7 +9,7 @@ from constants import (
     SIGNATURE_CHOICE,
     BENCHMARK_CELL_TYPE_GROUP,
     SAVE_MODEL,
-    N_INPUT,
+    N_GENES,
     N_SAMPLES,
     GENERATIVE_MODELS,
     BASELINES,
@@ -45,19 +45,19 @@ if BENCHMARK_DATASET == "TOY":
 elif BENCHMARK_DATASET == "CTI":
     adata = sc.read("/home/owkin/project/cti/cti_adata.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=2500,
+                     keep_genes=N_GENES,
                      batch_key="donor_id")
 elif BENCHMARK_DATASET == "CTI_RAW":
     warnings.warn("The raw data of this adata is on adata.raw.X, but the normalised "
                   "adata.X will be used here")
     adata = sc.read("/home/owkin/data/cross-tissue/omics/raw/local.h5ad")
     preprocess_scrna(adata,
-                     keep_genes=2500,
+                     keep_genes=N_GENES,
                      batch_key="donor_id",
     )
 elif BENCHMARK_DATASET == "CTI_PROCESSED":
     # Load processed for speed-up (already filtered, normalised, etc.)
-    adata = sc.read("/home/owkin/data/cti_data/processed/cti_processed_2500.h5ad")
+    adata = sc.read(f"/home/owkin/data/cti_data/processed/cti_processed_{N_GENES}.h5ad")
 
 # %% load signature
 logger.info(f"Loading signature matrix: {SIGNATURE_CHOICE} | {BENCHMARK_CELL_TYPE_GROUP}...")
@@ -113,7 +113,7 @@ if GENERATIVE_MODELS != []:
     # 3. MixupVI
     if "MixupVI" in GENERATIVE_MODELS:
         logger.info("Train mixupVI ...")
-        model_path = f"project/models/{BENCHMARK_DATASET}_{BENCHMARK_CELL_TYPE_GROUP}_{N_INPUT}_mixupvi.pkl"
+        model_path = f"project/models/{BENCHMARK_DATASET}_{BENCHMARK_CELL_TYPE_GROUP}_{N_GENES}_mixupvi.pkl"
         mixupvi_model = fit_mixupvi(adata_train,
                                     model_path,
                                     cell_type_group="cell_types_grouped",

--- a/run_pseudobulk_benchmark.py
+++ b/run_pseudobulk_benchmark.py
@@ -9,6 +9,7 @@ from constants import (
     SIGNATURE_CHOICE,
     BENCHMARK_CELL_TYPE_GROUP,
     SAVE_MODEL,
+    N_INPUT,
     N_SAMPLES,
     GENERATIVE_MODELS,
     BASELINES,
@@ -112,7 +113,7 @@ if GENERATIVE_MODELS != []:
     # 3. MixupVI
     if "MixupVI" in GENERATIVE_MODELS:
         logger.info("Train mixupVI ...")
-        model_path = f"project/models/{BENCHMARK_DATASET}_{BENCHMARK_CELL_TYPE_GROUP}_mixupvi.pkl"
+        model_path = f"project/models/{BENCHMARK_DATASET}_{BENCHMARK_CELL_TYPE_GROUP}_{N_INPUT}_mixupvi.pkl"
         mixupvi_model = fit_mixupvi(adata_train,
                                     model_path,
                                     cell_type_group="cell_types_grouped",
@@ -129,12 +130,12 @@ results_group = {}
 
 for n in num_cells:
     logger.info(f"Pseudobulk simulation with {n} sampled cells ...")
-    adata_pseudobulk_test_counts, adata_pseudobulk_test_rc, df_proportions_test = create_dirichlet_pseudobulk_dataset(
+    all_adata_samples_test, adata_pseudobulk_test_counts, adata_pseudobulk_test_rc, df_proportions_test = create_dirichlet_pseudobulk_dataset(
         adata_test,
         prior_alphas = None,
         n_sample = N_SAMPLES,
         n_cells = n,
-        add_sparsity=True
+        add_sparsity=False # useless in the current modifications
     )
     # decomment following for Sanity check 2.
     # adata_pseudobulk_test_counts, adata_pseudobulk_test_rc, df_proportions_test = create_uniform_pseudobulk_dataset(
@@ -147,6 +148,7 @@ for n in num_cells:
         adata_train=adata_train,
         adata_pseudobulk_test_counts=adata_pseudobulk_test_counts,
         adata_pseudobulk_test_rc=adata_pseudobulk_test_rc,
+        all_adata_samples_test=all_adata_samples_test,
         df_proportions_test=df_proportions_test,
         signature=signature,
         intersection=intersection,

--- a/scvi/model/_mixupvi.py
+++ b/scvi/model/_mixupvi.py
@@ -1,5 +1,9 @@
 import logging
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Sequence, Tuple
+
+import torch
+import numpy as np
+from anndata import AnnData
 
 from ._scvi import SCVI
 from scvi.module import MixUpVAE
@@ -42,3 +46,85 @@ class MixUpVI(SCVI):
                   plan_kwargs=plan_kwargs,
                   **trainer_kwargs,
             )
+
+    @torch.inference_mode()
+    def get_latent_representation(
+        self,
+        adata: Optional[AnnData] = None,
+        indices: Optional[Sequence[int]] = None,
+        get_pseudobulk: bool = True,
+        give_mean: bool = True,
+        mc_samples: int = 5000,
+        batch_size: Optional[int] = None,
+        return_dist: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """Return the latent representation for each cell.
+
+        This is typically denoted as :math:`z_n`.
+
+        Parameters
+        ----------
+        adata
+            AnnData object with equivalent structure to initial AnnData. If `None`, defaults to the
+            AnnData object used to initialize the model.
+        indices
+            Indices of cells in adata to use. If `None`, all cells are used.
+        get_pseudobulk
+            Give the pseudobulk latent representation instead of the single cell batch representation.
+        give_mean
+            Give mean of distribution or sample from it.
+        mc_samples
+            For distributions with no closed-form mean (e.g., `logistic normal`), how many Monte Carlo
+            samples to take for computing mean.
+        batch_size
+            Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
+        return_dist
+            Return (mean, variance) of distributions instead of just the mean.
+            If `True`, ignores `give_mean` and `mc_samples`. In the case of the latter,
+            `mc_samples` is used to compute the mean of a transformed distribution.
+            If `return_dist` is true the untransformed mean and variance are returned.
+
+        Returns
+        -------
+        Low-dimensional representation for each cell or a tuple containing its mean and variance.
+        """
+        self._check_if_trained(warn=False)
+
+        adata = self._validate_anndata(adata)
+        scdl = self._make_data_loader(
+            adata=adata, indices=indices, batch_size=adata.n_obs
+        )
+        latent = []
+        latent_qzm = []
+        latent_qzv = []
+        for tensors in scdl:
+            inference_inputs = self.module._get_inference_input(tensors)
+            outputs = self.module.inference(**inference_inputs)
+            suffix = ""
+            if get_pseudobulk:
+                suffix = "_pseudobulk"
+            if "qz" in outputs:
+                qz = outputs[f"qz{suffix}"]
+            else:
+                qz_m, qz_v = outputs["qz_m"], outputs["qz_v"]
+                qz = torch.distributions.Normal(qz_m, qz_v.sqrt())
+            if give_mean:
+                # does each model need to have this latent distribution param?
+                if self.module.latent_distribution == "ln":
+                    samples = qz.sample([mc_samples])
+                    z = torch.nn.functional.softmax(samples, dim=-1)
+                    z = z.mean(dim=0)
+                else:
+                    z = qz.loc
+            else:
+                z = outputs[f"z{suffix}"]
+
+            latent += [z.cpu()]
+            latent_qzm += [qz.loc.cpu()]
+            latent_qzv += [qz.scale.square().cpu()]
+        return (
+            (torch.cat(latent_qzm).numpy(), torch.cat(latent_qzv).numpy())
+            if return_dist
+            else torch.cat(latent).numpy()
+        )
+


### PR DESCRIPTION
Three features have been changed to make performances of mixupvi in benchmark be good again:
1. Add sparsity = False
2. Use nnls = True
3. For mixupvi **only**, get the latent representation of a pseudobulk with the categorical covariates being averaged in the right way.

**However, notice that now add sparsity = True would only add sparsity to other methods than mixupvi (because of how this quick fix is done), therefore I have decided to comment the related part of the code, so that no one uses it by mistake.**
**Moreover, categorical covariates will only be averaged in the right way for pseudobulks for mixupvi, not for scvi.**